### PR TITLE
Add configurable Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,3 +577,10 @@ MIT License (see repository).
 - Initial release with FastAPI service, ppstructure integration, MarkItDown conversion, LLM JSON extraction, overlays, and tests with coverage.
 - Added mock switches (`MOCK_LLM`, `MOCK_PP`) and policy control (`PP_POLICY`).
 - Hardened tests and added coverage reports (HTML + terminal).
+
+---
+
+## 20) Swagger/OpenAPI Docs
+
+- The FastAPI app serves interactive Swagger docs at `/docs` and the OpenAPI spec at `/openapi.json`.
+- Toggle these routes with the `DOCS_ENABLED` environment variable (`1` = enabled, `0` = disabled).

--- a/config.py
+++ b/config.py
@@ -43,6 +43,9 @@ PPSTRUCT_MAX_PAGES        = get_env_int("PPSTRUCT_MAX_PAGES", 9999)
 # Logging
 LOG_LEVEL = get_env_str("LOG_LEVEL", "INFO")  # DEBUG|INFO|WARNING|ERROR
 
+# Swagger/OpenAPI docs
+DOCS_ENABLED = get_env_int("DOCS_ENABLED", 1)  # 1=enable interactive docs
+
 # Reports
 REPORTS_DIR = get_env_str("REPORTS_DIR", "/mnt/data/reports")
 REPORT_TTL_HOURS = get_env_int("REPORT_TTL_HOURS", 72)

--- a/main.py
+++ b/main.py
@@ -26,7 +26,12 @@ from clients import *  # unified import as clients_pkg
 
 setup_logging()
 log = get_logger(__name__)
-app = FastAPI(title="Template-Guided RAG Extractor")
+app = FastAPI(
+    title="Template-Guided RAG Extractor",
+    docs_url="/docs" if DOCS_ENABLED else None,
+    redoc_url="/redoc" if DOCS_ENABLED else None,
+    openapi_url="/openapi.json" if DOCS_ENABLED else None,
+)
 
 # ---------------- Security ----------------
 def get_api_key(x_api_key: Optional[str] = Header(None)):

--- a/tests/test_docs_toggle.py
+++ b/tests/test_docs_toggle.py
@@ -1,0 +1,25 @@
+import importlib
+from fastapi.testclient import TestClient
+
+
+def test_docs_toggle(monkeypatch):
+    # Ensure docs are enabled by default
+    monkeypatch.setenv("DOCS_ENABLED", "1")
+    import config, main
+    importlib.reload(config)
+    importlib.reload(main)
+    client = TestClient(main.app)
+    assert client.get("/docs").status_code == 200
+
+    # Disable docs and reload
+    monkeypatch.setenv("DOCS_ENABLED", "0")
+    importlib.reload(config)
+    importlib.reload(main)
+    client = TestClient(main.app)
+    assert client.get("/docs").status_code == 404
+
+    # Restore for other tests
+    monkeypatch.setenv("DOCS_ENABLED", "1")
+    importlib.reload(config)
+    importlib.reload(main)
+


### PR DESCRIPTION
## Summary
- expose FastAPI's Swagger and OpenAPI routes
- control documentation availability via `DOCS_ENABLED`
- document and test docs toggle

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. pytest --cov=. --cov-report=term-missing --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_68975eae07648325b5d1e301543b6ef0